### PR TITLE
Added CustomTabIntent Support

### DIFF
--- a/config/taint_config.yml
+++ b/config/taint_config.yml
@@ -126,6 +126,7 @@ sinks:
   - { method: "<android.app.Notification$Builder: android.app.Notification$Builder setDeleteIntent(android.app.PendingIntent)>", index: 0 }
   - { method: "<android.app.Notification$Builder: android.app.Notification$Builder setFullScreenIntent(android.app.PendingIntent,boolean)>", index: 0 }
   - { method: "<android.widget.RemoteViews: void setOnClickPendingIntent(int,android.app.PendingIntent)>", index: 1 }
+  - { method: "<androidx.browser.customtabs.CustomTabsIntent: void launchUrl(android.content.Context,android.net.Uri)>", index: 1 }
 
 transfers:
   - { method: "<android.content.Intent: java.lang.String getStringExtra(java.lang.String)>", from: base, to: result }

--- a/src/main/java/com/thorfinn/poc/TaiEFlowAgent.java
+++ b/src/main/java/com/thorfinn/poc/TaiEFlowAgent.java
@@ -87,12 +87,22 @@ public class TaiEFlowAgent extends Agent<TaiEAgentModels.FlowRequest, TaiEAgentM
                FALSE POSITIVE if: explicit component set OR FLAG_IMMUTABLE used OR PendingIntent never leaves app process OR setPackage() restricts recipient.
                NOTE: If targetSdkVersion >= 31 and no FLAG_MUTABLE, system throws exception - code likely sets a flag, verify which one.
 
+            9. CustomTabIntent Vulnerability: App uses CustomTabsIntent.launchUrl() with attacker-controlled URL (from Intent extra, deep link, or other input) without validation. If the app communicates with the loaded URL using postMessage APIs, the attacker can load their own malicious URL and exploit the postMessage calls.
+               TRUE POSITIVE if: source exported AND attacker controls URL AND no validation/sanitization of URL before launchUrl().
+               FALSE POSITIVE if: not exported OR URL is hardcoded OR strict allowlist enforced OR URL validated against known safe domains.
+               MANUAL REVIEW NOTE:
+               - Mention the following points AS THEY ARE as references for the end-user to review themselves:
+                  1. Check for postMessage communication between the app and Custom Tab.
+                  2. Check for relaxed `requestPostMessageChannel` implementation.
+                  3. https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsSession#requestPostMessageChannel(android.net.Uri)
+                  4. https://developer.android.com/reference/androidx/browser/customtabs/PostMessageServiceConnection
+
             YOUR JOB:
             1. Is this flow a TRUE POSITIVE or FALSE POSITIVE?
             2. If TRUE POSITIVE, generate a concrete POC.
 
             POC PATTERNS:
-            1. WebView Vulnerability: Single adb command opening attacker URL with all required parameters.
+            1. WebView / CustomTab Vulnerability: Single adb command opening attacker URL with all required parameters.
             2. Third-Party Package Context Code Execution: Describe the attack steps.
             3. Intent Redirection: Single adb command targeting a non-exported component (identify from manifest). No generic examples.
             4. Implicit Intent Interception: Describe the attack and provide sample attacker AndroidManifest.xml intent-filter.

--- a/src/main/java/com/thorfinn/poc/TaiEFlowAgent.java
+++ b/src/main/java/com/thorfinn/poc/TaiEFlowAgent.java
@@ -88,14 +88,15 @@ public class TaiEFlowAgent extends Agent<TaiEAgentModels.FlowRequest, TaiEAgentM
                NOTE: If targetSdkVersion >= 31 and no FLAG_MUTABLE, system throws exception - code likely sets a flag, verify which one.
 
             9. CustomTabIntent Vulnerability: App uses CustomTabsIntent.launchUrl() with attacker-controlled URL (from Intent extra, deep link, or other input) without validation. If the app communicates with the loaded URL using postMessage APIs, the attacker can load their own malicious URL and exploit the postMessage calls.
-               TRUE POSITIVE if: source exported AND attacker controls URL AND no validation/sanitization of URL before launchUrl().
+               Determine whether the app implements postMessage communication with the custom tab:
+                    1. PostMessage communication has been implemented between the app and the custom tab if:
+                        a) The app calls CustomTabsSession.requestPostMessageChannel() with the custom tab's URL. https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsSession#requestPostMessageChannel(android.net.Uri)
+                        b) The app implements a PostMessageServiceConnection to handle postMessage communication. https://developer.android.com/reference/androidx/browser/customtabs/PostMessageServiceConnection
+                        c) The app calls CustomTabsSession.postMessage() to send messages to the custom tab. https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsSession#postMessage(java.lang.String,android.os.Bundle)
+                        d) The app listens for messages from the custom tab using onPostMessage() handler registered via CustomTabsCallback. https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsCallback#onPostMessage(java.lang.String,android.os.Bundle)
+                    2. If postMessage communication is present, the app may be vulnerable to attacks if the custom tab's URL is attacker-controlled and the app does not validate or sanitize the URL before calling launchUrl().
+               TRUE POSITIVE if: source exported AND attacker controls URL AND no validation/sanitization of URL before launchUrl(). Even if no postmessage communication is present, the app may still be vulnerable to attacks if the custom tab's URL is attacker-controlled and the app does not validate or sanitize the URL before calling launchUrl().
                FALSE POSITIVE if: not exported OR URL is hardcoded OR strict allowlist enforced OR URL validated against known safe domains.
-               MANUAL REVIEW NOTE:
-               - Mention the following points AS THEY ARE as references for the end-user to review themselves:
-                  1. Check for postMessage communication between the app and Custom Tab.
-                  2. Check for relaxed `requestPostMessageChannel` implementation.
-                  3. https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsSession#requestPostMessageChannel(android.net.Uri)
-                  4. https://developer.android.com/reference/androidx/browser/customtabs/PostMessageServiceConnection
 
             YOUR JOB:
             1. Is this flow a TRUE POSITIVE or FALSE POSITIVE?

--- a/src/main/java/com/thorfinn/poc/TaiEPOC.java
+++ b/src/main/java/com/thorfinn/poc/TaiEPOC.java
@@ -92,13 +92,23 @@ public class TaiEPOC implements poc {
                VULNERABLE (all three required): (1) Wrapped Intent is implicit - no setComponent/setClass/setClassName/setPackage/new Intent(ctx,Class.class); (2) FLAG_MUTABLE used OR no flag with targetSdkVersion < 31; (3) PendingIntent reaches attacker via an exposure sink.
                FALSE POSITIVE if: explicit component set OR FLAG_IMMUTABLE used OR PendingIntent never leaves app process OR setPackage() restricts recipient.
                NOTE: If targetSdkVersion >= 31 and no FLAG_MUTABLE, system throws exception - code likely sets a flag, verify which one.
+
+            9. CustomTabIntent Vulnerability: App uses CustomTabsIntent.launchUrl() with attacker-controlled URL (from Intent extra, deep link, or other input) without validation. If the app communicates with the loaded URL using postMessage APIs, the attacker can load their own malicious URL and exploit the postMessage calls.
+               TRUE POSITIVE if: source exported AND attacker controls URL AND no validation/sanitization of URL before launchUrl().
+               FALSE POSITIVE if: not exported OR URL is hardcoded OR strict allowlist enforced OR URL validated against known safe domains.
+               MANUAL REVIEW NOTE:
+               - Mention the following points AS THEY ARE as references for the end-user to review themselves:
+                  1. Check for postMessage communication between the app and Custom Tab.
+                  2. Check for relaxed `requestPostMessageChannel` implementation.
+                  3. https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsSession#requestPostMessageChannel(android.net.Uri)
+                  4. https://developer.android.com/reference/androidx/browser/customtabs/PostMessageServiceConnection
             
             YOUR JOB:
             1. Is this flow a TRUE POSITIVE or FALSE POSITIVE?
             2. If TRUE POSITIVE, generate a concrete POC.
             
             POC PATTERNS:
-            1. WebView Vulnerability: Single adb command opening attacker URL (use https://example.com in case of arbitrary URL else decide yourself on cases of endswith etc.) with all required parameters.
+            1. WebView / CustomTab Vulnerability: Single adb command opening attacker URL (use https://example.com in case of arbitrary URL else decide yourself on cases of endswith etc.) with all required parameters.
             2. Third-Party Package Context Code Execution: Describe the attack steps.
             3. Intent Redirection: Single adb command targeting a non-exported component (identify from manifest). No generic examples.
             4. Implicit Intent Interception: Describe the attack and provide sample attacker AndroidManifest.xml intent-filter.

--- a/src/main/java/com/thorfinn/poc/TaiEPOC.java
+++ b/src/main/java/com/thorfinn/poc/TaiEPOC.java
@@ -94,14 +94,15 @@ public class TaiEPOC implements poc {
                NOTE: If targetSdkVersion >= 31 and no FLAG_MUTABLE, system throws exception - code likely sets a flag, verify which one.
 
             9. CustomTabIntent Vulnerability: App uses CustomTabsIntent.launchUrl() with attacker-controlled URL (from Intent extra, deep link, or other input) without validation. If the app communicates with the loaded URL using postMessage APIs, the attacker can load their own malicious URL and exploit the postMessage calls.
-               TRUE POSITIVE if: source exported AND attacker controls URL AND no validation/sanitization of URL before launchUrl().
+               Determine whether the app implements postMessage communication with the custom tab:
+                    1. PostMessage communication has been implemented between the app and the custom tab if:
+                        a) The app calls CustomTabsSession.requestPostMessageChannel() with the custom tab's URL. https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsSession#requestPostMessageChannel(android.net.Uri)
+                        b) The app implements a PostMessageServiceConnection to handle postMessage communication. https://developer.android.com/reference/androidx/browser/customtabs/PostMessageServiceConnection
+                        c) The app calls CustomTabsSession.postMessage() to send messages to the custom tab. https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsSession#postMessage(java.lang.String,android.os.Bundle)
+                        d) The app listens for messages from the custom tab using onPostMessage() handler registered via CustomTabsCallback. https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsCallback#onPostMessage(java.lang.String,android.os.Bundle)
+                    2. If postMessage communication is present, the app may be vulnerable to attacks if the custom tab's URL is attacker-controlled and the app does not validate or sanitize the URL before calling launchUrl().
+               TRUE POSITIVE if: source exported AND attacker controls URL AND no validation/sanitization of URL before launchUrl(). Even if no postmessage communication is present, the app may still be vulnerable to attacks if the custom tab's URL is attacker-controlled and the app does not validate or sanitize the URL before calling launchUrl().
                FALSE POSITIVE if: not exported OR URL is hardcoded OR strict allowlist enforced OR URL validated against known safe domains.
-               MANUAL REVIEW NOTE:
-               - Mention the following points AS THEY ARE as references for the end-user to review themselves:
-                  1. Check for postMessage communication between the app and Custom Tab.
-                  2. Check for relaxed `requestPostMessageChannel` implementation.
-                  3. https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsSession#requestPostMessageChannel(android.net.Uri)
-                  4. https://developer.android.com/reference/androidx/browser/customtabs/PostMessageServiceConnection
             
             YOUR JOB:
             1. Is this flow a TRUE POSITIVE or FALSE POSITIVE?


### PR DESCRIPTION
Custom Tabs are a feature in Android browsers that gives app developers a way to add a customized browser experience directly within their app.

The following attack surface is possible with CustomTabs:
- Using [launchUrl](https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsIntent#launchUrl(android.content.Context,android.net.Uri)) method to load arbitrary domains.
- This can be exploited when a postMessage channel is created between the app and custom tab for communication, using a [PostMessageServiceConnection](https://developer.android.com/reference/androidx/browser/customtabs/PostMessageServiceConnection)
- Apps can claim themselves to be an origin, using which they communicate with domains. A webpage can choose wheather to engage with the app based on this origin. A Relaxed [postMessageOrigin](https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsSession#requestPostMessageChannel(android.net.Uri)) can be problematic.

Thorfinn test reports generated on custom test app:
[thorfinn_report.html](https://github.com/user-attachments/files/31139525/thorfinn_report.html)
[thorfinn_report.json](https://github.com/user-attachments/files/31139526/thorfinn_report.json)
